### PR TITLE
Don't redefine Array.to_h if defined

### DIFF
--- a/lib/modalsupport/array.rb
+++ b/lib/modalsupport/array.rb
@@ -31,11 +31,12 @@ class Array
   # you can set default or provide a block just as with Hash::new
   # Note: if you use [key, value1, value2, value#], hash[key] will
   # be [value1, value2, value#]
-  def to_h(default=nil, &block)
-    # code by Stefan Rusterholz fixed for Ruby 1.9.2; see http://www.ruby-forum.com/topic/138218
-    hash = block_given? ? Hash.new(&block) : Hash.new(default)
-    each { |(key, *value)| hash[key]=value.size>1 ? value : value.first }
-    hash
+  unless [].respond_to?(:to_h)
+    def to_h(default=nil, &block)
+      # code by Stefan Rusterholz fixed for Ruby 1.9.2; see http://www.ruby-forum.com/topic/138218
+      hash = block_given? ? Hash.new(&block) : Hash.new(default)
+      each { |(key, *value)| hash[key]=value.size>1 ? value : value.first }
+      hash
+    end
   end
-  
 end

--- a/lib/modalsupport/string.rb
+++ b/lib/modalsupport/string.rb
@@ -44,7 +44,6 @@ class String
     txt = self.gsub(/\t/, ' '*8)
     mx = txt.scan(/^ *[^\n\r]/).flatten.map{|s| s[-1,1]==' ' ? nil : (s.size-1)}.compact.min
     if mx && mx>0
-      re = Regexp.new('^ {1,'+mx.to_s+"}")
       txt.gsub!(/^ {1,#{mx}}/, "")
     end
     lines = txt.split(/\r?\n/)


### PR DESCRIPTION
Also remove superfluous statement in String.unindent that causes a ruby warning to be thrown